### PR TITLE
Fixed app start up issue on Linux

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -39,7 +39,7 @@ module.exports = function main() {
 
   // Fixes rendering bug on Linux when sandbox === true (Electron 11.0)
   if (process.platform === 'linux') {
-    app.disableHardwareAcceleration();
+    app.commandLine.appendSwitch('disable-gpu-sandbox'); 
   }
 
   app.on('will-finish-launching', function () {


### PR DESCRIPTION
App would not start on Ubuntu 22.04 because of GPU sand box. This appears to be a problem with chromium and adding the flag --disable-gpu-sandbox fixes it.

### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1.
2.
3.

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
